### PR TITLE
Adicionar um menu simplificado com o título do blog centralizado

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,0 +1,3 @@
+<div class="menu">
+    <a href="/">{{ .Site.Title }}</a>
+</div>

--- a/layouts/partials/top.html
+++ b/layouts/partials/top.html
@@ -9,6 +9,9 @@
 
     <link rel="stylesheet" href="{{ "css/normalize.css" | relURL }}">
     <link rel="stylesheet" href="{{ "css/fontawesome-all.min.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "css/menu.css" | relURL }}">
 </head>
 
 <body>
+
+{{ partial "menu.html" . }}

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -1,0 +1,11 @@
+.menu {
+    padding: 15px;
+    background-color: #1E1E1E;
+    text-align: center;
+}
+
+.menu a {
+    text-decoration: none;
+    color: #FBFBFB;
+    font-size: 1.3em;
+}


### PR DESCRIPTION
Este PR soluciona a tarefa #5 adicionando apenas o menu simplificado.

Ainda não foi levado em consideração o tipo de letra usada no tema.

resolve #5 