### PR TITLE
Adicionar a logo na esquerda do título (caso configurado)

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,3 +1,6 @@
 <div class="menu">
+    {{ if .Site.Params.Profile.Img }}
+    <img src="{{ .Site.Params.Profile.Img }}" alt="Profile Logo" width="45px" height="45px">
+    {{ end }}
     <a href="/">{{ .Site.Title }}</a>
 </div>

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -1,7 +1,17 @@
 .menu {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     padding: 15px;
     background-color: #1E1E1E;
     text-align: center;
+}
+
+.menu img {
+    border-radius: 50%;
+    padding: 3px;
+    margin-right: 10px;
+    border: 1px solid #FBFBFB;
 }
 
 .menu a {


### PR DESCRIPTION
Este PR soluciona a tarefa #6 adicionando a logo ao lado esquerdo do título da página, sendo que o código referente a logo só pode aparecer quando a mesma estiver configurada.

resolve #6 