### PR TITLE
Adicionar a lista de links

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,6 +1,19 @@
 <div class="menu">
-    {{ if .Site.Params.Profile.Img }}
-    <img src="{{ .Site.Params.Profile.Img }}" alt="Profile Logo" width="45px" height="45px">
-    {{ end }}
-    <a href="/">{{ .Site.Title }}</a>
+    <div class="menu-id">
+        {{ if .Site.Params.Profile.Img }}
+        <img src="{{ .Site.Params.Profile.Img }}" alt="Profile Logo" width="45px" height="45px">
+        {{ end }}
+        <a href="/">{{ .Site.Title }}</a>
+    </div>
+    <nav class="menu-nav">
+        <ul>
+            {{ range .Site.Params.Links }}
+            <li>
+                <a target="_blank" href="{{ .Url }}">
+                    <i class="fab {{ .Icon }}"></i>
+                </a>
+            </li>
+            {{ end }}
+        </ul>
+    </nav>
 </div>

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -1,21 +1,65 @@
 .menu {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 15px;
+    justify-content: space-between;
+    padding: 15px 100px;
+    flex-wrap: wrap;
     background-color: #1E1E1E;
-    text-align: center;
 }
 
-.menu img {
+.menu-id {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.menu-id img {
     border-radius: 50%;
     padding: 3px;
     margin-right: 10px;
     border: 1px solid #FBFBFB;
 }
 
-.menu a {
+.menu-id a {
     text-decoration: none;
     color: #FBFBFB;
     font-size: 1.3em;
+}
+
+.menu-nav {
+    display: flex;
+    align-items: center;
+}
+
+.menu-nav ul{
+    display: flex;
+    list-style: none;
+    margin: 0px;
+    padding: 0px;
+}
+
+.menu-nav ul li i{
+    color: #FBFBFB;
+    margin-right: 25px;
+    font-size: 1.3em;
+}
+
+@media only screen and (max-width: 768px) {
+    .menu {
+        padding: 8px;
+        justify-content: center;
+    }
+
+    .menu-nav {
+        width: 100%;
+    }
+
+    .menu-nav ul{
+        width: 100%;
+        margin: 15px 0px 0px;
+        justify-content: space-around;
+    }
+    
+    .menu-nav ul li i{
+        margin-right: 0px;
+    }
 }


### PR DESCRIPTION
Este PR soluciona a tarefa #7 adicionando a lista de links (caso configurada) na barra de menu.

resolve #7 

### Configuração

No arquivo de configuração do blog, o usuário pode configurar a lista de links da seguinte forma:

```yml
Params:
  Links:
    - Name: "Github"
      Url: "https://github.com/kelvinoenning"
      Icon: "fa-github"
    - Name: "Twitter"
      Url: "https://twitter.com/"
      Icon: "fa-twitter"
    - Name: "Facebook"
      Url: "https://www.facebook.com/kelvin.stangoenning"
      Icon: "fa-facebook-f"
    - Name: "Instagram"
      Url: "https://www.instagram.com/kelvinstang"
      Icon: "fa-instagram"
    - Name: "Linkedin"
      Url: "https://br.linkedin.com/in/kelvinoenning"
      Icon: "fa-linkedin-in"
```

O código do icone pode ser acessado no site do [Font Awesome](https://fontawesome.com/icons?d=gallery), utilizando somente o final que refencia ao `ID` do icone.

**Exemplo:***

Exemplo para o ícone do ***facebook***, onde na configuração é usado somente o `fa-linkedin-in`.

```
<i class="fab fa-linkedin-in"></i>
```

### Barra de menu no modo desktop

![image](https://user-images.githubusercontent.com/5251782/54222679-a2682300-44d4-11e9-828c-5a8b3a196e61.png)

### Barra de menu no modo Tablet (Ipad)

![image](https://user-images.githubusercontent.com/5251782/54222697-b14ed580-44d4-11e9-836f-cd924bf0271f.png)

### Barra de menu no modo Tablet (Ipad Pro)

![image](https://user-images.githubusercontent.com/5251782/54222721-be6bc480-44d4-11e9-9dea-c4133d53e524.png)

### Barra de menu no modo Celular (Maiores - Pixel 2)

![image](https://user-images.githubusercontent.com/5251782/54222824-ec510900-44d4-11e9-9532-5b398f740021.png)

### Barra de menu no modo Celular (Menores - Iphone 4)

![image](https://user-images.githubusercontent.com/5251782/54222748-cdeb0d80-44d4-11e9-8178-5936d479228d.png)
