### PR TITLE
Construção da página para a apresentação do post

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
         <div class="post">
             <div class="post-content">
                 <div class="post-title">
-                    <a href="/">{{ .Title }}</a>
+                    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
                 </div>
                 <div class="post-description">
                     {{ .Params.Description }}

--- a/layouts/partials/top.html
+++ b/layouts/partials/top.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="{{ "css/fontawesome-all.min.css" | relURL }}">
     <link rel="stylesheet" href="{{ "css/minimalist.css" | relURL }}">
     <link rel="stylesheet" href="{{ "css/menu.css" | relURL }}">
+    <link rel="stylesheet" href="{{ "css/article.css" | relURL }}">
 </head>
 
 <body>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,0 +1,20 @@
+{{ partial "top.html" . }}
+
+<div class="container">
+    <div class="article">
+        <div class="return">
+            <a class="return" href="/">Voltar</a>
+        </div>
+        <div class="article-date">
+            {{ dateFormat "02-01-2006 04:05" .Date }}
+        </div>
+        <div class="article-title">
+            <h1>{{ .Title }}</h1>
+        </div>
+        <div class="article-content">
+            {{ .Content }}
+        </div>
+    </div>
+</div>
+
+{{ partial "bottom.html" . }}

--- a/static/css/article.css
+++ b/static/css/article.css
@@ -1,0 +1,39 @@
+.article a {
+    color: #dd4c4f;
+    font-size: 1.3em;
+}
+
+.article .return a {
+    text-decoration: none;
+    color: #343a40;
+}
+
+.article img[src*='#center'] {
+    display: block;
+    margin: auto;
+    max-width: 100%;
+}
+
+.article-date {
+    color: rgba(0,0,0,.44);
+}
+
+.article-date, .article-title {
+    text-align: center;
+}
+
+.article-title {
+    font-size: 1.2em;
+    color: #343a40;
+}
+
+.article-content {
+    color: #343a40;
+}
+
+.article-file {
+    text-align: center;
+    font-weight: bold;
+    font-size: 0.85em;
+    color: #343a40;
+}


### PR DESCRIPTION
Este PR soluciona a tarefa #9 adicionando a página para a apresentação do artigo.

Foi adicionado apenas o mínimo para a apresentação, onde outras configurações serão adicionados como melhoria, e o `highlight` do código será adicionado na tarefa #10 .

resolve #9 

### Exemplo
![image](https://user-images.githubusercontent.com/5251782/54555421-772e7980-4995-11e9-8719-0d025ee0756a.png)
