### PR TITLE
Adicionar a configuração de SEO na página inicial

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,0 +1,8 @@
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="ie=edge">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+{{ range $key, $value := .Site.Params.Meta -}}
+    <meta name="{{ $key }}" content="{{ $value }}">
+{{- end}}

--- a/layouts/partials/top.html
+++ b/layouts/partials/top.html
@@ -2,10 +2,9 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
+    {{ partial "meta.html" . }}
+
+    <title>{{ .Site.Title }}</title>
 
     <link rel="stylesheet" href="{{ "css/normalize.css" | relURL }}">
     <link rel="stylesheet" href="{{ "css/fontawesome-all.min.css" | relURL }}">
@@ -17,4 +16,4 @@
 
 <body>
 
-{{ partial "menu.html" . }}
+    {{ partial "menu.html" . }}


### PR DESCRIPTION
Este PR soluciona a tarefa #11.

Foi criado uma `partial` chamada `meta.html` responsável por gerenciar todas as tags `meta` do site.

resolve #11 

### Exemplo de uso

Para montar as metas do site, o usuário deverá configurar as tags como parâmetro dentro do arquivo de configuração do blog `./config.yml`.

```yml
Params:
  Meta:
    Description: "Tag description"
    keywords: "Tag keywords"
    Robots: "Tag robots"
    Revisit-after: "Tag revisit-after"
    Language: "Tag language"
    Generator: "Tag generator"
```