### PR TITLE
Mudar a variável do título do blog

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -3,7 +3,7 @@
         {{ if .Site.Params.Profile.Img }}
         <img src="{{ .Site.Params.Profile.Img }}" alt="Profile Logo" width="45px" height="45px">
         {{ end }}
-        <a href="/">{{ .Site.Title }}</a>
+        <a href="/">{{ .Site.Params.Profile.Title }}</a>
     </div>
     <nav class="menu-nav">
         <ul>


### PR DESCRIPTION
Este PR soluciona a tarefa #27.

Foi criado uma nova variável para o título apresentado no menu.

Fix #27 

### Exemplo de uso

A variável fica nos parâmetros de profile do usuário, no mesmo lugar onde o usuário pode escolher a imagem mostrada no menu.
```yml
Params:
  Profile:
    Img: "..."
    Title: "..."
```