### PR TITLE
Adicionar a configuração de SEO na página do post

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -3,6 +3,17 @@
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
-{{ range $key, $value := .Site.Params.Meta -}}
-    <meta name="{{ $key }}" content="{{ $value }}">
-{{- end}}
+{{ if eq $.Type "post" }}
+    <title>{{ (index $.Params "title") }}</title>
+{{ else }}
+    <title>{{ .Site.Title }}</title>
+{{ end }}
+
+{{ range $key, $value := .Site.Params.Meta }}
+    {{ $.Scratch.Set $key $value }}
+    {{ if eq $.Type "post" }}
+        {{ if eq $key "description" }}{{ $.Scratch.Set $key (index $.Params $key) }}{{ end }}
+        {{ if eq $key "keywords" }}{{ $.Scratch.Set $key (delimit (index $.Params $key) ", ") }}{{ end }}
+    {{ end }}
+    <meta name="{{ $key }}" content="{{ $.Scratch.Get $key }}">
+{{ end}}

--- a/layouts/partials/top.html
+++ b/layouts/partials/top.html
@@ -4,8 +4,6 @@
 <head>
     {{ partial "meta.html" . }}
 
-    <title>{{ .Site.Title }}</title>
-
     <link rel="stylesheet" href="{{ "css/normalize.css" | relURL }}">
     <link rel="stylesheet" href="{{ "css/fontawesome-all.min.css" | relURL }}">
     <link rel="stylesheet" href="{{ "css/minimalist.css" | relURL }}">


### PR DESCRIPTION
Este PR resolve a tarefa #12 modificando a forma que a partial `meta.html` trabalha, fazendo com que atenda a página de apresentação do artigo em questão.

resolve #12 