### PR TITLE
Bug com o espaçamento do container

### DIFF
--- a/static/css/minimalist.css
+++ b/static/css/minimalist.css
@@ -63,7 +63,7 @@
 @media only screen and (max-width: 768px) {
     .container {
         margin: 0;
-        padding: 0;
+        padding: 10;
     }
 
     .post { 
@@ -71,6 +71,7 @@
     }
 
     .post-content {
+        margin: 5px 0px;
         height: auto;
         padding-bottom: 45px;
     }


### PR DESCRIPTION
Este PR resolve a tarefa de bug #25 modificando as `margens` e `paddings` do `container` e `post-content`.

fix #25

# Exemplo
![image](https://user-images.githubusercontent.com/5251782/54650169-fef6af80-4a8b-11e9-833b-614d190e1fa1.png)

![image](https://user-images.githubusercontent.com/5251782/54650179-07e78100-4a8c-11e9-8b9a-b73ef56ff1e0.png)