### PR TITLE
Possibilitar aos mobiles o retorno da página com um botão fixo no canto inferior direito

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -5,6 +5,9 @@
         <div class="return">
             <a class="return" href="/">Voltar</a>
         </div>
+        <div class="return-mobile">
+            <a class="return" href="/">Voltar</a>
+        </div>
         <div class="article-date">
             {{ dateFormat "02-01-2006 04:05" .Date }}
         </div>

--- a/static/css/article.css
+++ b/static/css/article.css
@@ -3,9 +3,25 @@
     font-size: 1.3em;
 }
 
-.article .return a {
+.article .return a, .article .return-mobile a {
     text-decoration: none;
     color: #343a40;
+}
+
+.article .return-mobile {
+    display: none;
+}
+
+.article .return-mobile a {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    margin: 10px;
+    padding: 5px;
+    color: #FBFBFB;
+    background-color: #343a40;
+    border-radius: 5px;
+    font-size: 1em;
 }
 
 .article img[src*='#center'] {
@@ -15,10 +31,11 @@
 }
 
 .article-date {
-    color: rgba(0,0,0,.44);
+    color: rgba(0, 0, 0, .44);
 }
 
-.article-date, .article-title {
+.article-date,
+.article-title {
     text-align: center;
 }
 
@@ -36,4 +53,10 @@
     font-weight: bold;
     font-size: 0.85em;
     color: #343a40;
+}
+
+@media only screen and (max-width: 768px) {
+    .article .return-mobile {
+        display: block;
+    }
 }


### PR DESCRIPTION
Este PR resolve a tarefa #26 adicionando mais um botão `voltar` no artigo e modificando o css para se adaptar a melhoria.

Foi adicionado um novo botão para não confundir as pessoas que já estão acostumadas com o `Voltar` de cima.

### Exemplo

![image](https://user-images.githubusercontent.com/5251782/54650710-85ac8c00-4a8e-11e9-85ba-6cbd648804a1.png)
