### PR TITLE
Fix compartilhamento com o twitter

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -22,7 +22,7 @@
             <a aria-label="Compartilhe no Facebook" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}">
                 <i class="fab fa-facebook fa-2x" aria-hidden="true" style="color:#3b5998"></i>
             </a>
-            <a aria-label="Compartilhe no Twitter" target="_blank" href='https://twitter.com/intent/tweet?text="{{ .Title }}" {{ .Permalink }}&hashtags={{ (index $.Params "twitter-hashtag") }}'>
+            <a aria-label="Compartilhe no Twitter" target="_blank" href='https://twitter.com/intent/tweet?text="{{ .Description }}" {{ .Permalink }}&hashtags={{ (index $.Params "twitter-hashtag") }}'>
                 <i class="fab fa-twitter fa-2x" aria-hidden="true" style="color:#1da1f2"></i>
             </a>
         </div>


### PR DESCRIPTION
Foi modificado o texto de compartilhamento, antes era compartilhado o `title` e agora foi modificado para `description`.