### PR TITLE
Adicionado o css para tabelas em posts

### DIFF
--- a/static/css/article.css
+++ b/static/css/article.css
@@ -65,6 +65,23 @@
     color: #dd4c4f;
 }
 
+.article-content table {
+    margin: 0 auto;
+    border-collapse: collapse;
+}
+
+.article-content table, th, td {
+    border: 1px solid #dfe2e5;;
+}
+
+.article-content table tr td, .article-content table tr th {
+    padding: 8px 15px;
+}
+
+.article-content table tr:nth-child(even) {
+    background-color: #f2f2f2;
+}
+
 .article-share {
     border-top: 1px solid rgba(0,0,0,.125);
 }


### PR DESCRIPTION
Este PR soluciona a tarefa #49, adicionando o css para tabelas escritas no post.

#### Exemplo

![image](https://user-images.githubusercontent.com/5251782/55597862-14273b80-5726-11e9-856d-6a410da148c4.png)
